### PR TITLE
Fix CI build by upgrading Node

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
       - name: Install Node.js dependencies
         run: npm install
       - name: Setup Pages


### PR DESCRIPTION
## Summary
- bump Node.js from 16 to 20 in GitHub Actions

This resolves the PostCSS error (`bundle.findLastIndex is not a function`) during the Pages build.

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888685bfae0832596220dbed0fb9731