### PR TITLE
Fix CI build by upgrading Node

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
       - name: Install Node.js dependencies
         run: npm install
       - name: Setup Pages

--- a/config.toml
+++ b/config.toml
@@ -97,7 +97,7 @@ DefaultContentLanguageInSubdir = true
   ]
 
   # Custom copyright - optional
-  copyright = "Copyright © 2024 - Fatos Halimi · All rights reserved"
+  copyright = "Copyright © {year} - Fatos Halimi · All rights reserved"
   favicon = "/favicon.png"
 
   # Color for the intro details and social links block, not applicable for dark mode

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,10 +1,11 @@
 <footer class="container p-6 mx-auto flex justify-between items-center">
   <span class="text-sm font-light">
-    {{ if (isset .Site.Params "copyright") }}
-    {{ .Site.Params.copyright | safeHTML }}
-    {{ else }}
-    {{ dateFormat "2006" now }} © {{ .Site.Title }}
-    {{ end }}
+  {{ $year := now.Format "2006" }}
+  {{ if (isset .Site.Params "copyright") }}
+  {{ replace .Site.Params.copyright "{year}" $year | safeHTML }}
+  {{ else }}
+  {{ $year }} © {{ .Site.Title }}
+  {{ end }}
   </span>
   <span onclick="window.scrollTo({top: 0, behavior: 'smooth'})" class="p-1 cursor-pointer">
     <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 24 24" stroke-width="1.5"


### PR DESCRIPTION
## Summary
- bump Node.js from 16 to 20 in GitHub Actions
- replace hardcoded year with `{year}` placeholder
- dynamically insert current year in the footer

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888685bfae0832596220dbed0fb9731